### PR TITLE
Remoção de letra 'a' duplicada.

### DIFF
--- a/textos/f4/geral/exod.txt
+++ b/textos/f4/geral/exod.txt
@@ -2166,7 +2166,7 @@ E todos os sábios de coração entre os que faziam a obra, fizeram o tabernácu
 \v Ex.36.9
 O comprimento da uma cortina era de vinte e oito côvados, e a largura de quatro côvados: todas as cortinas tinham uma mesma medida.
 \v Ex.36.10
-E juntou as cinco cortinas a uma com a outra: também uniu as outras cinco cortinas uma com aa outra.
+E juntou as cinco cortinas uma com a outra: também uniu as outras cinco cortinas uma com a outra.
 \v Ex.36.11
 E fez as laçadas de cor de material azul na orla de uma cortina, na margem, à juntura; e assim fez na orla à extremidade da segunda cortina, na juntura.
 \v Ex.36.12

--- a/textos/f4/n4/exod.txt
+++ b/textos/f4/n4/exod.txt
@@ -2166,7 +2166,7 @@ E todos os sábios de coração entre os que faziam a obra, fizeram o tabernácu
 \v Ex.36.9
 O comprimento da uma cortina era de vinte e oito côvados, e a largura de quatro côvados: todas as cortinas tinham uma mesma medida.
 \v Ex.36.10
-E juntou as cinco cortinas a uma com a outra: também uniu as outras cinco cortinas uma com aa outra.
+E juntou as cinco cortinas uma com a outra: também uniu as outras cinco cortinas uma com a outra.
 \v Ex.36.11
 E fez as laçadas de cor de material azul na orla de uma cortina, na margem, à juntura; e assim fez na orla à extremidade da segunda cortina, na juntura.
 \v Ex.36.12

--- a/textos/f4/tr/exod.txt
+++ b/textos/f4/tr/exod.txt
@@ -2166,7 +2166,7 @@ E todos os sábios de coração entre os que faziam a obra, fizeram o tabernácu
 \v Ex.36.9
 O comprimento da uma cortina era de vinte e oito côvados, e a largura de quatro côvados: todas as cortinas tinham uma mesma medida.
 \v Ex.36.10
-E juntou as cinco cortinas a uma com a outra: também uniu as outras cinco cortinas uma com aa outra.
+E juntou as cinco cortinas uma com a outra: também uniu as outras cinco cortinas uma com a outra.
 \v Ex.36.11
 E fez as laçadas de cor de material azul na orla de uma cortina, na margem, à juntura; e assim fez na orla à extremidade da segunda cortina, na juntura.
 \v Ex.36.12


### PR DESCRIPTION
Achei um aparente erro, um "aa" no final deste versículo, simplesmente mudei para "a". Então reparei que também parecia ter um "a" sobrando no começo do versículo.
Desculpem o incômodo, espero ter ajudado.